### PR TITLE
Adds a tileDisplay param to override default fade-in behaviour

### DIFF
--- a/lib/src/plugin/heatmap_layer.dart
+++ b/lib/src/plugin/heatmap_layer.dart
@@ -8,13 +8,15 @@ class HeatMapLayer extends StatefulWidget {
   final HeatMapOptions heatMapOptions;
   final HeatMapDataSource heatMapDataSource;
   final Stream<void>? reset;
+  final TileDisplay tileDisplay;
 
   HeatMapLayer(
       {super.key,
       HeatMapOptions? heatMapOptions,
       required this.heatMapDataSource,
       List<WeightedLatLng>? initialData,
-      this.reset})
+      this.reset,
+      this.tileDisplay = const TileDisplay.fadeIn()})
       : heatMapOptions = heatMapOptions ?? HeatMapOptions();
 
   @override
@@ -62,6 +64,7 @@ class _HeatMapLayerState extends State<HeatMapLayer> {
           backgroundColor: Colors.transparent,
           tileSize: 256,
           urlTemplate: pseudoUrl,
+          tileDisplay: widget.tileDisplay,
           tileProvider: HeatMapTilesProvider(
               heatMapOptions: widget.heatMapOptions,
               dataSource: widget.heatMapDataSource)),


### PR DESCRIPTION
Hi @tprebs - hope you're well!

Our requirements are for the heatmap layer to appear instantaneously rather than using the `TileLayer`'s 100ms fadeIn delay, as we update heatmap data regularly.

This PR adds a new `tileDisplay` parameter, so that this default behaviour can be changed.

If a `tileData` value is not provided, it will default to `TileDisplay.fadeIn()` which is the current default behaviour, so anyone who doesn't provide this will see no change in functionality.