### PR TITLE
Adds maxZoom param to override TileLayer's default

### DIFF
--- a/lib/src/plugin/heatmap_layer.dart
+++ b/lib/src/plugin/heatmap_layer.dart
@@ -9,6 +9,7 @@ class HeatMapLayer extends StatefulWidget {
   final HeatMapDataSource heatMapDataSource;
   final Stream<void>? reset;
   final TileDisplay tileDisplay;
+  final double maxZoom;
 
   HeatMapLayer(
       {super.key,
@@ -16,7 +17,8 @@ class HeatMapLayer extends StatefulWidget {
       required this.heatMapDataSource,
       List<WeightedLatLng>? initialData,
       this.reset,
-      this.tileDisplay = const TileDisplay.fadeIn()})
+      this.tileDisplay = const TileDisplay.fadeIn(),
+      this.maxZoom = 18.0})
       : heatMapOptions = heatMapOptions ?? HeatMapOptions();
 
   @override
@@ -63,6 +65,7 @@ class _HeatMapLayerState extends State<HeatMapLayer> {
       child: TileLayer(
           backgroundColor: Colors.transparent,
           tileSize: 256,
+          maxZoom: widget.maxZoom,
           urlTemplate: pseudoUrl,
           tileDisplay: widget.tileDisplay,
           tileProvider: HeatMapTilesProvider(


### PR DESCRIPTION
Hi @tprebs 👋 

Heatmaps were only displaying up to a zoom level of 18, as this is the default for the TileLayer.

Our use case requires them to display up to a zoom level of 20, so this adds a parameter to set the `maxZoom`. If a maxZoom is not specified, it will default to 18 - so no change in functionality for anyone who doesn't specify it.