### PR TITLE
Fix for heatmap not loading

### DIFF
--- a/lib/src/plugin/heat_map_tiles_provider.dart
+++ b/lib/src/plugin/heat_map_tiles_provider.dart
@@ -141,7 +141,7 @@ class HeatMapImage extends ImageProvider<HeatMapImage> {
       : generator = HeatMap(heatmapOptions, size, size, data);
 
   @override
-  ImageStreamCompleter load(HeatMapImage key, decode) {
+  ImageStreamCompleter loadImage(HeatMapImage key, decode) {
     return MultiFrameImageStreamCompleter(codec: _generate(), scale: 1);
   }
 


### PR DESCRIPTION
I'm assuming `ImageStreamCompleter load()` from dart:ui was updated to `loadImage()` and the override stopped working.
This is my first ever pull request not sure what else to add 😆 
@tprebs 