### PR TITLE
Update Example Code and README to be up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Add [`flutter_map`](https://github.com/fleaflet/flutter_map) and `flutter_map_he
 
 ```yaml
 dependencies:
-  flutter_map: 4.0.0
+  flutter_map: ^6.0.0
   flutter_map_heatmap: any # or the latest version on Pub
+  latlong2: ^0.9.0
 ```
 
 Flutter heatmaps is implemented as a tile provider. 
@@ -27,11 +28,10 @@ Add it in your FlutterMap and configure it using `HeatMapOptions`.
 ```dart
   Widget build(BuildContext context) {
     return FlutterMap(
-      options: new MapOptions(center: new LatLng(57.8827, -6.0400), zoom: 8.0),
+      options: new MapOptions(initialCenter: new LatLng(57.8827, -6.0400), initialZoom: 8.0),
       children: [
         TileLayer(
-            urlTemplate: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-            subdomains: ['a', 'b', 'c']),
+            urlTemplate: "https://tile.openstreetmap.org/{z}/{x}/{y}.png"),
         if (data.isNotEmpty) HeatMapLayer(
           heatMapDataSource: InMemoryHeatMapDataSource(data: data),
           heatMapOptions: HeatMapOptions(gradient: this.gradients[this.index],

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -83,11 +83,11 @@ class _MyHomePageState extends State<MyHomePage> {
     });
 
     final map = new FlutterMap(
-      options: new MapOptions(center: new LatLng(57.8827, -6.0400), zoom: 8.0),
+      options: new MapOptions(
+          initialCenter: new LatLng(57.8827, -6.0400), initialZoom: 8.0),
       children: [
         TileLayer(
-            urlTemplate: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-            subdomains: ['a', 'b', 'c']),
+            urlTemplate: "https://tile.openstreetmap.org/{z}/{x}/{y}.png"),
         if (data.isNotEmpty)
           HeatMapLayer(
             heatMapDataSource: InMemoryHeatMapDataSource(data: data),

--- a/example/macos/Runner/DebugProfile.entitlements
+++ b/example/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/example/macos/Runner/Release.entitlements
+++ b/example/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
This Pull request does the following:
- update the example code for the openstreetmap layer according to https://github.com/openstreetmap/operations/issues/737
- Update the dependencies requirerement to reflect the fact that flutter_map@6.0.0 and latlong2 are required and change the depreacted field to the up to date one's
- Update the macos security requirements to have acces to the network